### PR TITLE
Update Gemfile with missing webrick requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2.0"
+gem "webrick", "~> 1.7"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"


### PR DESCRIPTION
Starting with Ruby 3.0, the webrick library, which Jekyll uses to serve websites locally, is no longer included in the standard library. You’ll need to manually add it to your project’s dependencies if it's not there by default.